### PR TITLE
feat(Lightbox) Adds fullscreen option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 2.0.0-beta.4
+
+- feat(LightboxConfig): Adds fullscreen option to the lightbox, closes [#43](https://github.com/MurhafSousli/ngx-gallery/issues/43).
+
+By default fullscreen is obtained on small screen (mobile) but now you can make it as default for all screens
+
+```ts
+GalleryModule.forRoot()
+LightboxModule.forRoot({
+  panelClass: 'fullscreen'
+})
+```
+
+- feat(Lightbox): Ability to define lightbox config using `lightbox.open()` method
+
+```ts
+openLightbox() {
+  this.lightbox.open(0, 'lightbox', {
+    panelClass: 'fullscreen'
+  });
+}
+```
+
 ## 2.0.0-beta.3
 
 - Prevents native click event bubbling, closes [#57](https://github.com/MurhafSousli/ngx-gallery/issues/57)

--- a/lib/lightbox/src/lightbox.model.ts
+++ b/lib/lightbox/src/lightbox.model.ts
@@ -3,5 +3,4 @@ export interface LightboxConfig {
   panelClass?: string;
   hasBackdrop?: boolean;
   keyboardShortcuts?: boolean;
-  fullScreen?: boolean;
 }

--- a/lib/lightbox/src/lightbox.service.ts
+++ b/lib/lightbox/src/lightbox.service.ts
@@ -37,12 +37,16 @@ export class Lightbox {
    * Open Lightbox Overlay
    * @param i - Current Index
    * @param id - Gallery ID
+   * @param config - Lightbox Config
    */
-  open(i = 0, id = 'lightbox') {
+  open(i = 0, id = 'lightbox', config?: LightboxConfig) {
+
+    const _config = config ? { ...this.config, ...config } : this.config;
+
     const overlayConfig: OverlayConfig = {
-      backdropClass: this.config.backdropClass,
-      panelClass: this.config.panelClass,
-      hasBackdrop: this.config.hasBackdrop,
+      backdropClass: _config.backdropClass,
+      panelClass: _config.panelClass,
+      hasBackdrop: _config.hasBackdrop,
       positionStrategy: this._overlay.position().global().centerHorizontally().centerVertically(),
       scrollStrategy: this._overlay.scrollStrategies.block()
     };
@@ -59,11 +63,11 @@ export class Lightbox {
     compRef.instance.id = id;
     compRef.instance.close = () => this.close();
 
-    if (this.config.hasBackdrop) {
+    if (_config.hasBackdrop) {
       this._overlayRef.backdropClick().subscribe(() => this.close());
     }
 
-    if (this.config.keyboardShortcuts) {
+    if (_config.keyboardShortcuts) {
       this._overlayRef.keydownEvents().subscribe((event) => {
         switch (event.keyCode) {
           case LEFT_ARROW:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngx-gallery/demo",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ngx-gallery/demo",
   "description": "Angular image gallery simplifies the process of creating beautiful image gallery for the web and mobile devices.",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "homepage": "http://github.com/murhafsousli/ng-gallery",
   "author": {
     "name": "Murhaf Sousli",


### PR DESCRIPTION
- feat(LightboxConfig): Adds fullscreen option to the lightbox, closes #43

By default fullscreen is obtained on small screen (mobile) but now you can make it as default for all screens

```ts
GalleryModule.forRoot()
LightboxModule.forRoot({
  panelClass: 'fullscreen'
})
```

- feat(Lightbox): Ability to define lightbox config using `lightbox.open()` method

```ts
openLightbox() {
  this.lightbox.open(0, 'lightbox', {
    panelClass: 'fullscreen'
  });
}
```