### PR TITLE
Strict null checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-gallery",
-  "version": "3.1.2",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -471,9 +471,9 @@
       }
     },
     "@fortawesome/angular-fontawesome": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-0.1.1.tgz",
-      "integrity": "sha512-74JdLuQWfYsrEaZ6ahTyiLzXQ6dfv8UApGXHOYdtGYqod1f+zsMz7GA8ivAnnrg4xytUJgCuejEx0G8+miBxlg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-0.2.1.tgz",
+      "integrity": "sha512-B77fIEjq9bgHGncx5sfFuANh6qow6+MLHbU6C7lMIdeLXykkWTWOiPk+CqlmPOYXIpUH1lNaVykgTSqAk65pIw==",
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/projects/core/src/lib/components/gallery.component.ts
+++ b/projects/core/src/lib/components/gallery.component.ts
@@ -48,8 +48,8 @@ export class GalleryComponent implements OnInit, OnChanges, OnDestroy {
   @Input() disableThumb: boolean = this._gallery.config.disableThumb;
   @Input() panSensitivity: number = this._gallery.config.panSensitivity;
   @Input() playerInterval: number = this._gallery.config.playerInterval;
-  @Input() itemTemplate: TemplateRef<any> = this._gallery.config.itemTemplate;
-  @Input() thumbTemplate: TemplateRef<any> = this._gallery.config.thumbTemplate;
+  @Input() itemTemplate: TemplateRef<any> | undefined = this._gallery.config.itemTemplate;
+  @Input() thumbTemplate: TemplateRef<any> | undefined = this._gallery.config.thumbTemplate;
   @Input() thumbMode: 'strict' | 'free' = this._gallery.config.thumbMode;
   @Input() imageSize: 'cover' | 'contain' = this._gallery.config.imageSize;
   @Input() slidingDirection: 'horizontal' | 'vertical' = this._gallery.config.slidingDirection;

--- a/projects/core/src/lib/directives/lazy.directive.ts
+++ b/projects/core/src/lib/directives/lazy.directive.ts
@@ -15,7 +15,7 @@ export class LazyDirective implements OnDestroy {
     this.loadImage(imagePath);
   }
 
-  @Output() loaded = new EventEmitter<string>();
+  @Output() loaded = new EventEmitter<string | null>();
   @Output() error = new EventEmitter<Error>();
 
   constructor() {

--- a/projects/core/src/lib/directives/tap-click.directive.ts
+++ b/projects/core/src/lib/directives/tap-click.directive.ts
@@ -13,7 +13,7 @@ export class TapClickDirective implements OnInit, OnDestroy {
   mc: any;
   clickListener: any;
   @Input() tapClickDisabled: boolean;
-  @Output() tapClick = new EventEmitter();
+  @Output() tapClick = new EventEmitter<null>();
 
   constructor(private el: ElementRef, private renderer: Renderer2) {
   }

--- a/projects/core/src/lib/gallery.module.ts
+++ b/projects/core/src/lib/gallery.module.ts
@@ -48,7 +48,7 @@ import { TapClickDirective } from './directives/tap-click.directive';
   ]
 })
 export class GalleryModule {
-  static forRoot(config?: GalleryConfig): ModuleWithProviders {
+  static forRoot(config?: Partial<GalleryConfig>): ModuleWithProviders {
 
     return {
       ngModule: GalleryModule,

--- a/projects/core/src/lib/models/config.model.ts
+++ b/projects/core/src/lib/models/config.model.ts
@@ -1,26 +1,26 @@
 import { TemplateRef } from '@angular/core';
 
 export interface GalleryConfig {
-  nav?: boolean;
-  dots?: boolean;
-  loop?: boolean;
-  thumb?: boolean;
-  zoomOut?: number;
-  navIcon?: string;
-  counter?: boolean;
-  gestures?: boolean;
-  autoPlay?: boolean;
-  thumbWidth?: number;
-  thumbHeight?: number;
-  loadingIcon?: string;
-  disableThumb?: boolean;
-  panSensitivity?: number;
-  playerInterval?: number;
+  nav: boolean;
+  dots: boolean;
+  loop: boolean;
+  thumb: boolean;
+  zoomOut: number;
+  navIcon: string;
+  counter: boolean;
+  gestures: boolean;
+  autoPlay: boolean;
+  thumbWidth: number;
+  thumbHeight: number;
+  loadingIcon: string;
+  disableThumb: boolean;
+  panSensitivity: number;
+  playerInterval: number;
   itemTemplate?: TemplateRef<any>;
   thumbTemplate?: TemplateRef<any>;
-  thumbMode?: 'strict' | 'free';
-  imageSize?: 'cover' | 'contain';
-  slidingDirection?: 'horizontal' | 'vertical';
-  loadingStrategy?: 'preload' | 'lazy' | 'default';
-  thumbPosition?: 'top' | 'left' | 'right' | 'bottom';
+  thumbMode: 'strict' | 'free';
+  imageSize: 'cover' | 'contain';
+  slidingDirection: 'horizontal' | 'vertical';
+  loadingStrategy: 'preload' | 'lazy' | 'default';
+  thumbPosition: 'top' | 'left' | 'right' | 'bottom';
 }

--- a/projects/core/src/lib/models/gallery.model.ts
+++ b/projects/core/src/lib/models/gallery.model.ts
@@ -1,17 +1,17 @@
 import { GalleryAction } from './constants';
 
 export interface GalleryState {
-  action?: GalleryAction;
-  items?: GalleryItem[];
-  currIndex?: number;
-  hasNext?: boolean;
-  hasPrev?: boolean;
-  isPlaying?: boolean;
+  action: GalleryAction;
+  items: GalleryItem[];
+  currIndex: number;
+  hasNext: boolean;
+  hasPrev: boolean;
+  isPlaying: boolean;
 }
 
 export interface GalleryItem {
-  data?: any;
-  type?: string;
+  data: any;
+  type: string;
 }
 
 export interface GalleryError {

--- a/projects/core/src/lib/services/gallery-ref.ts
+++ b/projects/core/src/lib/services/gallery-ref.ts
@@ -68,7 +68,7 @@ export class GalleryRef {
   /**
    * Activate player actions listener
    */
-  activatePlayer(): Observable<GalleryState> {
+  activatePlayer(): Observable<GalleryState | {}> {
     return this.playerActions.pipe(
       switchMap((e: GalleryState) =>
         e.isPlaying ? of({}).pipe(
@@ -83,7 +83,7 @@ export class GalleryRef {
    * Set gallery state
    * @param state
    */
-  private setState(state: GalleryState) {
+  private setState(state: Partial<GalleryState>) {
     this._state.next({...this._state.value, ...state});
   }
 
@@ -91,7 +91,7 @@ export class GalleryRef {
    * Set gallery config
    * @param config
    */
-  setConfig(config: GalleryConfig) {
+  setConfig(config: Partial<GalleryConfig>) {
     this._config.next({...this._config.value, ...config});
   }
 

--- a/projects/core/src/lib/services/gallery.service.ts
+++ b/projects/core/src/lib/services/gallery.service.ts
@@ -25,15 +25,15 @@ export class Gallery {
    * @param id
    * @param config
    */
-  ref(id = 'root', config?: GalleryConfig): GalleryRef {
+  ref(id = 'root', config?: Partial<GalleryConfig>): GalleryRef {
     if (this._instances.has(id)) {
-      const galleryRef = this._instances.get(id);
+      const galleryRef = this._instances.get(id)!;
       if (config) {
         galleryRef.setConfig({...this.config, ...config});
       }
       return galleryRef;
     } else {
-      return this._instances.set(id, new GalleryRef({...this.config, ...config}, this.deleteInstance(id))).get(id);
+      return this._instances.set(id, new GalleryRef({...this.config, ...config}, this.deleteInstance(id))).get(id)!;
     }
   }
 

--- a/projects/core/src/lib/utils/gallery.token.ts
+++ b/projects/core/src/lib/utils/gallery.token.ts
@@ -1,4 +1,4 @@
 import { InjectionToken } from '@angular/core';
 import { GalleryConfig } from '../models';
 
-export const GALLERY_CONFIG = new InjectionToken<GalleryConfig>('galleryConfig');
+export const GALLERY_CONFIG = new InjectionToken<Partial<GalleryConfig>>('galleryConfig');

--- a/projects/core/tsconfig.lib.json
+++ b/projects/core/tsconfig.lib.json
@@ -15,8 +15,7 @@
     "lib": [
       "dom",
       "es2017"
-    ],
-    "strictNullChecks": true
+    ]
   },
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,

--- a/projects/core/tsconfig.lib.json
+++ b/projects/core/tsconfig.lib.json
@@ -15,7 +15,8 @@
     "lib": [
       "dom",
       "es2017"
-    ]
+    ],
+    "strictNullChecks": true
   },
   "angularCompilerOptions": {
     "annotateForClosureCompiler": true,

--- a/projects/lightbox/src/lib/lightbox.model.ts
+++ b/projects/lightbox/src/lib/lightbox.model.ts
@@ -1,7 +1,7 @@
 export interface LightboxConfig {
-  backdropClass?: string;
-  panelClass?: string;
-  hasBackdrop?: boolean;
-  keyboardShortcuts?: boolean;
-  closeIcon?: string;
+  backdropClass: string;
+  panelClass: string;
+  hasBackdrop: boolean;
+  keyboardShortcuts: boolean;
+  closeIcon: string;
 }

--- a/projects/lightbox/src/lib/lightbox.model.ts
+++ b/projects/lightbox/src/lib/lightbox.model.ts
@@ -5,3 +5,6 @@ export interface LightboxConfig {
   keyboardShortcuts: boolean;
   closeIcon: string;
 }
+
+export type PartialLightboxConfig = Partial<LightboxConfig>;
+

--- a/projects/lightbox/src/lib/lightbox.module.ts
+++ b/projects/lightbox/src/lib/lightbox.module.ts
@@ -8,7 +8,7 @@ import { LightboxDirective } from './lightbox.directive';
 import { LightboxConfig } from './lightbox.model';
 import { LIGHTBOX_CONFIG } from './lightbox.token';
 
-export function lightboxFactory(config: LightboxConfig, gallery: Gallery, overlay: Overlay) {
+export function lightboxFactory(config: Partial<LightboxConfig>, gallery: Gallery, overlay: Overlay) {
   return new Lightbox(config, gallery, overlay);
 }
 
@@ -29,7 +29,7 @@ export function lightboxFactory(config: LightboxConfig, gallery: Gallery, overla
   ]
 })
 export class LightboxModule {
-  static forRoot(config?: LightboxConfig): ModuleWithProviders {
+  static forRoot(config?: Partial<LightboxConfig>): ModuleWithProviders {
 
     return {
       ngModule: LightboxModule,

--- a/projects/lightbox/src/lib/lightbox.service.ts
+++ b/projects/lightbox/src/lib/lightbox.service.ts
@@ -43,7 +43,7 @@ export class Lightbox {
    * @param id - Gallery ID
    * @param config - Lightbox Config
    */
-  open(i = 0, id = 'lightbox', config?: LightboxConfig) {
+  open(i = 0, id = 'lightbox', config?: Partial<LightboxConfig>) {
 
     const _config = config ? {...this._config, ...config} : this._config;
 

--- a/projects/lightbox/src/lib/lightbox.service.ts
+++ b/projects/lightbox/src/lib/lightbox.service.ts
@@ -6,7 +6,7 @@ import { Gallery } from '@ngx-gallery/core';
 import { Subject } from 'rxjs';
 
 import { LIGHTBOX_CONFIG } from './lightbox.token';
-import { LightboxConfig } from './lightbox.model';
+import { LightboxConfig, PartialLightboxConfig } from './lightbox.model';
 import { defaultConfig } from './lightbox.default';
 import { LightboxComponent } from './lightbox.component';
 
@@ -25,7 +25,7 @@ export class Lightbox {
   /** Stream that emits when lightbox is closed */
   closed = new Subject<string>();
 
-  constructor(@Inject(LIGHTBOX_CONFIG) config: LightboxConfig, private _gallery: Gallery, private _overlay: Overlay) {
+  constructor(@Inject(LIGHTBOX_CONFIG) config: PartialLightboxConfig, private _gallery: Gallery, private _overlay: Overlay) {
     this._config = {...defaultConfig, ...config};
   }
 
@@ -33,7 +33,7 @@ export class Lightbox {
    * Set Lightbox Config
    * @param config - LightboxConfig
    */
-  setConfig(config: LightboxConfig) {
+  setConfig(config: Partial<LightboxConfig>) {
     this._config = {...this._config, ...config};
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
       "es2017",
       "dom"
     ],
+    "strictNullChecks": true,
     "paths": {
       "core": [
         "dist/core"

--- a/tslint.json
+++ b/tslint.json
@@ -64,7 +64,7 @@
       "ignore-params"
     ],
     "no-misused-new": true,
-    "no-non-null-assertion": true,
+    "no-non-null-assertion": false,
     "no-shadowed-variable": true,
     "no-string-literal": false,
     "no-string-throw": true,


### PR DESCRIPTION
At the moment due to problems with angular/core ngx-gallery wont build with aot for codebase with strict null checks enabled. By enabling strict null checks it for this library we fix this problem for those codebases and in the same time improve quality of this project.

kind of fixes https://github.com/MurhafSousli/ngx-gallery/issues/201

It might be breaking for some users, i'm not sure which models are public dependencies. Anyway please take a look and let me know if you are interested in this kind of changes.

