### PR TITLE
Fixes vertical scroll on touch devices #161

### DIFF
--- a/CONTRIBUTION.MD
+++ b/CONTRIBUTION.MD
@@ -3,7 +3,7 @@
 After you clone the repo and install the project dependencies, you should prepare the build setup by running the following command only for the first time:
 
 ```bash
-npm run prepare-build
+npm run init-build
 ```
 
 *This will build and link all the packages.*

--- a/projects/core/src/lib/components/gallery-slider.component.ts
+++ b/projects/core/src/lib/components/gallery-slider.component.ts
@@ -99,9 +99,13 @@ export class GallerySliderComponent implements OnInit, OnChanges, OnDestroy {
   ngOnInit() {
     if (this.config.gestures && typeof Hammer !== 'undefined') {
 
+      const direction = this.config.slidingDirection === SlidingDirection.Horizontal
+        ? Hammer.DIRECTION_HORIZONTAL
+        : Hammer.DIRECTION_VERTICAL;
+
       // Activate gestures
       this._hammer = new Hammer(this._el.nativeElement);
-      this._hammer.get('pan').set({direction: Hammer.DIRECTION_ALL});
+      this._hammer.get('pan').set({ direction });
 
       this._zone.runOutsideAngular(() => {
         // Move the slider
@@ -168,6 +172,9 @@ export class GallerySliderComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private verticalPan(e) {
+    if (!(e.direction & Hammer.DIRECTION_UP && e.offsetDirection & Hammer.DIRECTION_VERTICAL)) {
+      return;
+    }
     if (e.velocityY > 0.3) {
       this.prev();
     } else if (e.velocityY < -0.3) {
@@ -184,6 +191,9 @@ export class GallerySliderComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private horizontalPan(e) {
+    if (!(e.direction & Hammer.DIRECTION_HORIZONTAL && e.offsetDirection & Hammer.DIRECTION_HORIZONTAL)) {
+      return;
+    }
     if (e.velocityX > 0.3) {
       this.prev();
     } else if (e.velocityX < -0.3) {

--- a/projects/core/src/lib/components/gallery-thumbs.component.ts
+++ b/projects/core/src/lib/components/gallery-thumbs.component.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { GalleryConfig, GalleryState, ThumbnailsPosition, ThumbnailsMode, GalleryError } from '../models';
+import { GalleryConfig, GalleryState, ThumbnailsPosition, ThumbnailsMode, GalleryError, SlidingDirection } from '../models';
 import { SliderState, WorkerState } from '../models/slider.model';
 
 declare const Hammer: any;
@@ -95,9 +95,22 @@ export class GalleryThumbsComponent implements OnInit, OnChanges, OnDestroy {
   ngOnInit() {
     if (this.config.gestures && !this.config.disableThumb && typeof Hammer !== 'undefined') {
 
+      let direction: number;
+
+      switch (this.config.thumbPosition) {
+        case ThumbnailsPosition.Right:
+        case ThumbnailsPosition.Left:
+          direction = Hammer.DIRECTION_VERTICAL;
+          break;
+        case ThumbnailsPosition.Top:
+        case ThumbnailsPosition.Bottom:
+          direction = Hammer.DIRECTION_HORIZONTAL;
+          break;
+      }
+
       // Activate gestures
       this._hammer = new Hammer(this._el.nativeElement);
-      this._hammer.get('pan').set({direction: Hammer.DIRECTION_ALL});
+      this._hammer.get('pan').set({ direction });
 
       this._zone.runOutsideAngular(() => {
         // Move the slider
@@ -220,6 +233,9 @@ export class GalleryThumbsComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private verticalPan(e: any) {
+    if (!(e.direction & Hammer.DIRECTION_UP && e.offsetDirection & Hammer.DIRECTION_VERTICAL)) {
+      return;
+    }
     if (e.velocityY > 0.3) {
       this.prev();
     } else if (e.velocityY < -0.3) {
@@ -236,6 +252,9 @@ export class GalleryThumbsComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private horizontalPan(e: any) {
+    if (!(e.direction & Hammer.DIRECTION_HORIZONTAL && e.offsetDirection & Hammer.DIRECTION_HORIZONTAL)) {
+      return;
+    }
     if (e.velocityX > 0.3) {
       this.prev();
     } else if (e.velocityX < -0.3) {

--- a/tslint.json
+++ b/tslint.json
@@ -44,7 +44,6 @@
       }
     ],
     "no-arg": true,
-    "no-bitwise": true,
     "no-console": [
       true,
       "debug",
@@ -53,6 +52,7 @@
       "timeEnd",
       "trace"
     ],
+    "no-bitwise": false,
     "no-construct": true,
     "no-debugger": true,
     "no-duplicate-super": true,


### PR DESCRIPTION
Fixes #161.

The direction for HammerJS panning is limited to only horizontal or vertical depending on your preference both for the gallery and the thumbs.

I also changed the `CONTRIBUTION.MD` file as the `prepare-build` task was called `init-build` as far as I could see.