### PR TITLE
Route a thumbLoadingIcon and thumbLoadingError to thumbnail component

### DIFF
--- a/projects/core/src/lib/components/gallery-thumb.component.ts
+++ b/projects/core/src/lib/components/gallery-thumb.component.ts
@@ -5,7 +5,12 @@ import { GalleryConfig } from '../models/config.model';
   selector: 'gallery-thumb',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <gallery-image [src]="data.thumb" [isThumbnail]="true" mode="indeterminate" (error)="error.emit($event)"></gallery-image>
+    <gallery-image [src]="data.thumb" 
+                   mode="indeterminate"
+                   [isThumbnail]="true" 
+                   [loadingIcon]="config.thumbLoadingIcon"
+                   [loadingError]="config.thumbLoadingError "
+                   (error)="error.emit($event)"></gallery-image>
 
     <div *ngIf="config.thumbTemplate" class="g-template g-thumb-template">
       <ng-container

--- a/projects/core/src/lib/components/templates/gallery-image.component.ts
+++ b/projects/core/src/lib/components/templates/gallery-image.component.ts
@@ -44,16 +44,19 @@ import { animationFrameScheduler, BehaviorSubject } from 'rxjs';
       </div>
 
       <ng-container *ngSwitchCase="'loading'">
-        <div *ngIf="isThumbnail; else isLarge" class="g-thumb-loading"></div>
-        <ng-template #isLarge>
-          <div class="g-loading">
-            <i *ngIf="loaderTemplate; else progressLoader"
-               [innerHTML]="loaderTemplate"></i>
-          </div>
+        <div *ngIf="loaderTemplate; else defaultLoader"
+             class="g-loading"
+             [innerHTML]="loaderTemplate">
+        </div>
+        <ng-template #defaultLoader>
+
+          <div *ngIf="isThumbnail; else progressLoader" class="g-thumb-loading"></div>
+
           <ng-template #progressLoader>
             <radial-progress [value]="progress" [mode]="mode"></radial-progress>
           </ng-template>
-        </ng-template>
+
+          </ng-template>
       </ng-container>
     </ng-container>
   `

--- a/projects/core/src/lib/models/config.model.ts
+++ b/projects/core/src/lib/models/config.model.ts
@@ -17,6 +17,8 @@ export interface GalleryConfig {
   thumbHeight?: number;
   loadingIcon?: string;
   loadingError?: string;
+  thumbLoadingIcon?: string;
+  thumbLoadingError?: string;
   disableThumb?: boolean;
   panSensitivity?: number;
   playerInterval?: number;


### PR DESCRIPTION
Creates the optional config options thumbLoadingIcon and thumbLoadingError to control what is being displayed when a thumbnail errors out.  Should be similar to how it is done for the main image component.