### PR TITLE
Removed HttpClientModule dependency from the GalleryModule

### DIFF
--- a/projects/core/src/lib/gallery.module.ts
+++ b/projects/core/src/lib/gallery.module.ts
@@ -1,6 +1,6 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
 
 import { GalleryConfig, GALLERY_CONFIG } from './models/config.model';
 
@@ -26,8 +26,7 @@ import { RequestCache, RequestCacheWithMap } from './services/cache.service';
 
 @NgModule({
   imports: [
-    CommonModule,
-    HttpClientModule
+    CommonModule
   ],
   providers: [
     {provide: RequestCache, useClass: RequestCacheWithMap},

--- a/projects/demo/src/app/pages/documentation/doc-core/doc-core/doc-core.component.html
+++ b/projects/demo/src/app/pages/documentation/doc-core/doc-core/doc-core.component.html
@@ -18,7 +18,7 @@
 
   <div class="usage-title">
     <span class="section-number">1</span>
-    <p>Import <code class="hljs">BrowserAnimationsModule</code> in the root module</p>
+    <p>Import <code class="hljs">BrowserAnimationsModule</code> and <code class="hljs">HttpClientModule</code> in the root module</p>
   </div>
 
   <p></p>

--- a/projects/demo/src/app/pages/documentation/doc-gallerize/doc-gallerize/doc-gallerize.component.html
+++ b/projects/demo/src/app/pages/documentation/doc-gallerize/doc-gallerize/doc-gallerize.component.html
@@ -20,7 +20,7 @@
   
   <div class="usage-title">
     <span class="section-number">1</span>
-    <p>Import <code class="hljs">BrowserAnimationsModule</code> in the root module</p>
+    <p>Import <code class="hljs">BrowserAnimationsModule</code> and <code class="hljs">HttpClientModule</code> in the root module</p>
   </div>
 
   <p></p>

--- a/projects/demo/src/app/pages/documentation/doc-lightbox/doc-lightbox/doc-lightbox.component.html
+++ b/projects/demo/src/app/pages/documentation/doc-lightbox/doc-lightbox/doc-lightbox.component.html
@@ -20,7 +20,7 @@
 
   <div class="usage-title">
     <span class="section-number">1</span>
-    <p>Import <code class="hljs">BrowserAnimationsModule</code> in the root module</p>
+    <p>Import <code class="hljs">BrowserAnimationsModule</code> and <code class="hljs">HttpClientModule</code> in the root module</p>
   </div>
 
   <p></p>


### PR DESCRIPTION
Fixes #277 

There's a whole threat about this issue in one of the Angular issues and I agree with this person commenting on the previous message: [https://github.com/angular/angular/issues/20575](https://github.com/angular/angular/issues/20575#issuecomment-526221149)

This PR would fix all of the problems all the people from #277 (and myself) are having, so I hope you agree with this solution. The only big downside is that this change is no longer backwards compatible. So it might mean a major release, but I leave that up to you as I think a lot of people already import the HttpClientModule anyway.