### PR TITLE
fix for url with special characters

### DIFF
--- a/projects/core/src/lib/components/templates/gallery-image.component.ts
+++ b/projects/core/src/lib/components/templates/gallery-image.component.ts
@@ -116,7 +116,7 @@ export class GalleryImageComponent implements OnInit, OnDestroy {
   }
 
   onLoaded(blobUrl: string) {
-    this.imageUrl = this._sanitizer.bypassSecurityTrustStyle(`url(${blobUrl})`);
+    this.imageUrl = this._sanitizer.bypassSecurityTrustStyle(`url("${blobUrl}")`);
     this._state.next('success');
   }
 


### PR DESCRIPTION
Image url containing special characters (eg. Korean characters) goes blank without error.
Adding quotes around the url fixes it.


see [https://stackoverflow.com/questions/2168855/is-quoting-the-value-of-url-really-necessary](https://stackoverflow.com/questions/2168855/is-quoting-the-value-of-url-really-necessary)