### PR TITLE
Feature #340, Fix bug #398

### DIFF
--- a/projects/ng-gallery/src/lib/components/gallery-thumbs.component.ts
+++ b/projects/ng-gallery/src/lib/components/gallery-thumbs.component.ts
@@ -208,27 +208,55 @@ export class GalleryThumbsComponent implements OnInit, OnChanges, OnDestroy {
    * Convert sliding state to styles
    */
   private getSliderStyles(state: WorkerState): any {
+    const containerWidth = this._el.nativeElement?.getBoundingClientRect().width;
+    const containerHeight = this._el.nativeElement?.getBoundingClientRect().height;
+    const itemsLength = this.state.items.length;
+    const {thumbWidth, thumbHeight} = this.config;
+    const currIndex = this.state.currIndex;
+    const minHorizontalShift = (itemsLength * thumbWidth - containerWidth / 2) + 1;
+    const minVerticalShift = (itemsLength * thumbHeight - containerHeight / 2) + 1;
+
     let value: number;
     switch (this.config.thumbPosition) {
       case ThumbnailsPosition.Top:
       case ThumbnailsPosition.Bottom:
         this.width = '100%';
         this.height = this.config.thumbHeight + 'px';
-        value = -(this.state.currIndex * this.config.thumbWidth) - (this.config.thumbWidth / 2 - state.value);
+        switch (this.config.thumbView) {
+          case 'contain':
+            if ((currIndex * thumbWidth + thumbWidth / 2) > containerWidth / 2) {
+              value = -(Math.min(currIndex * thumbWidth + thumbWidth / 2, minHorizontalShift));
+            } else {
+              value = -(containerWidth / 2 - 1);
+            }
+            break;
+          default:
+            value = -(currIndex * thumbWidth) - (thumbWidth / 2 - state.value);
+        }
         return {
           transform: `translate3d(${value}px, 0, 0)`,
-          width: this.state.items.length * this.config.thumbWidth + 'px',
+          width: itemsLength * thumbWidth + 'px',
           height: '100%'
         };
       case ThumbnailsPosition.Left:
       case ThumbnailsPosition.Right:
         this.width = this.config.thumbWidth + 'px';
         this.height = '100%';
-        value = -(this.state.currIndex * this.config.thumbHeight) - (this.config.thumbHeight / 2 - state.value);
+        switch (this.config.thumbView) {
+          case 'contain':
+            if ((currIndex * thumbHeight + thumbHeight / 2) > containerHeight / 2) {
+              value = -(Math.min(currIndex * thumbHeight + thumbHeight / 2, minVerticalShift));
+            } else {
+              value = -(containerHeight / 2 - 1);
+            }
+            break;
+          default:
+            value = -(currIndex * thumbHeight) - (thumbHeight / 2 - state.value);
+        }
         return {
           transform: `translate3d(0, ${value}px, 0)`,
           width: '100%',
-          height: this.state.items.length * this.config.thumbHeight + 'px'
+          height: itemsLength * thumbHeight + 'px'
         };
     }
   }

--- a/projects/ng-gallery/src/lib/components/gallery.component.ts
+++ b/projects/ng-gallery/src/lib/components/gallery.component.ts
@@ -67,6 +67,7 @@ export class GalleryComponent implements OnInit, OnChanges, OnDestroy {
   @Input() slidingDirection: 'horizontal' | 'vertical' = this._gallery.config.slidingDirection;
   @Input() loadingStrategy: 'preload' | 'lazy' | 'default' = this._gallery.config.loadingStrategy;
   @Input() thumbPosition: 'top' | 'left' | 'right' | 'bottom' = this._gallery.config.thumbPosition;
+  @Input() thumbView: 'default' | 'contain' = this._gallery.config.thumbView;
 
   // Inputs used by the lightbox
 
@@ -106,6 +107,7 @@ export class GalleryComponent implements OnInit, OnChanges, OnDestroy {
       dotsSize: this.dotsSize,
       imageSize: this.imageSize,
       thumbMode: this.thumbMode,
+      thumbView: this.thumbView,
       thumbWidth: this.thumbWidth,
       thumbHeight: this.thumbHeight,
       disableThumb: this.disableThumb,

--- a/projects/ng-gallery/src/lib/components/templates/gallery-iframe.component.ts
+++ b/projects/ng-gallery/src/lib/components/templates/gallery-iframe.component.ts
@@ -16,8 +16,10 @@ import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 export class GalleryIframeComponent {
 
   iframeSrc: SafeResourceUrl;
+  videoSrc: string;
 
   @Input('src') set src(src: string) {
+    this.videoSrc = src;
     this.iframeSrc = this._sanitizer.bypassSecurityTrustResourceUrl(src);
   }
 
@@ -26,6 +28,10 @@ export class GalleryIframeComponent {
       if (shouldPause) {
         const iframe: HTMLIFrameElement = this.iframe.nativeElement;
         iframe.src = null;
+
+        if (!this.autoplay && this.videoSrc) {
+          this.iframeSrc = this._sanitizer.bypassSecurityTrustResourceUrl(this.videoSrc);
+        }
       }
     }
   }

--- a/projects/ng-gallery/src/lib/models/config.model.ts
+++ b/projects/ng-gallery/src/lib/models/config.model.ts
@@ -31,4 +31,5 @@ export interface GalleryConfig {
   slidingDirection?: 'horizontal' | 'vertical';
   loadingStrategy?: 'preload' | 'lazy' | 'default';
   thumbPosition?: 'top' | 'left' | 'right' | 'bottom';
+  thumbView?: 'default' | 'contain';
 }

--- a/projects/ng-gallery/src/lib/models/constants.ts
+++ b/projects/ng-gallery/src/lib/models/constants.ts
@@ -55,3 +55,8 @@ export enum GalleryItemType {
   Youtube = 'youtube',
   Iframe = 'iframe'
 }
+
+export enum ThumbnailsView {
+  Default = 'default',
+  Contain = 'contain',
+}


### PR DESCRIPTION
#### BUG #398: 

If the video has `autoplay=true`, everything works fine, but if autoplay is absent or is false, then when switching to the next/previous  video, the next/previous frame has src=null and when returning to it src is still null


#### FEATURE #340: 
#### My decision:
Add one more parameter to the configuration as `thumbView = 'default' | 'contain'`
If `thumbView = 'default'` or missing, thumbnails are displayed by default. With `thumbView = 'contain'` like in the video below:

https://user-images.githubusercontent.com/26595679/139582156-ad285111-0bc3-4ed2-a52d-6d6226d92e3f.mp4

https://user-images.githubusercontent.com/26595679/139582176-8793abb2-a319-4029-991a-3899b6dd11a4.mp4



