### PR TITLE
fix(gallery-service): Preserve ref config

### DIFF
--- a/projects/ng-gallery/src/lib/services/gallery.service.ts
+++ b/projects/ng-gallery/src/lib/services/gallery.service.ts
@@ -28,7 +28,7 @@ export class Gallery {
     if (this._instances.has(id)) {
       const galleryRef = this._instances.get(id);
       if (config) {
-        galleryRef.setConfig({ ...this.config, ...config });
+        galleryRef.setConfig({ ...galleryRef.config, ...config });
       }
       return galleryRef;
     } else {


### PR DESCRIPTION
- When updating the configuration of an existing gallery ref, use the existing configuration as the basis instead of the service's default config.

This addresses issue #592 