### PR TITLE
fix: add missing loadingAttr on gallery-image in gallery-thumb template

### DIFF
--- a/projects/ng-gallery/src/lib/components/gallery-thumb.component.ts
+++ b/projects/ng-gallery/src/lib/components/gallery-thumb.component.ts
@@ -22,6 +22,7 @@ import { GalleryItemType } from '../models/constants';
     <gallery-image [src]="data.thumb"
                    [alt]="data.alt + '-thumbnail'"
                    [isThumbnail]="true"
+                   [loadingAttr]="config.loadingAttr"
                    [loadingIcon]="config.thumbLoadingIcon"
                    [loadingError]="config.thumbLoadingError"
                    (error)="error.emit($event)"></gallery-image>


### PR DESCRIPTION
Adds a missing loadingAttr on `<gallery-img>` in the gallery-thumb template.