### PR TITLE
fix(ci): pin npm to 11.15.0 so `npm stage publish` works

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,10 @@ jobs:
             echo "NPM_TAG=latest" >> $GITHUB_OUTPUT
           fi
 
+      - name: Upgrade npm to 11.15.0
+        # npm stage publish requires npm >= 11.15.0, newer than the npm bundled with Node 24.
+        run: npm install -g npm@11.15.0
+
       # 🟢 Submits the package directly to your npm holding queue
       - name: Stage Publish to NPM via Trusted Publishing
         run: |


### PR DESCRIPTION
The `publish` job runs `npm stage publish`, which requires npm 11.15.0 or newer, but `actions/setup-node` with Node 24 installs npm 11.13.0, so the staged-publish step fails on the next release. This adds `npm install -g npm@11.15.0` in the same `publish` job right before that step.